### PR TITLE
Remove unused using statements across all files

### DIFF
--- a/Shr2.Interfaces/ICacheProvider.cs
+++ b/Shr2.Interfaces/ICacheProvider.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Shr2.Interfaces
+﻿namespace Shr2.Interfaces
 {
     public interface ICacheProvider
     {

--- a/Shr2.Interfaces/IConverter.cs
+++ b/Shr2.Interfaces/IConverter.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Shr2.Interfaces
+﻿namespace Shr2.Interfaces
 {
     public interface IConverter
     {

--- a/Shr2.Interfaces/IStorageProvider.cs
+++ b/Shr2.Interfaces/IStorageProvider.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Shr2.Interfaces
+﻿namespace Shr2.Interfaces
 {
     public interface IStorageProvider
     {

--- a/Shr2/Controllers/RedirectController.cs
+++ b/Shr2/Controllers/RedirectController.cs
@@ -1,8 +1,4 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;

--- a/Shr2/Controllers/V1Controller.cs
+++ b/Shr2/Controllers/V1Controller.cs
@@ -1,8 +1,4 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Shr2.Interfaces;

--- a/Shr2/EnvConfig.cs
+++ b/Shr2/EnvConfig.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.Logging;
 using Shr2.Models;
 using Shr2.Interfaces;

--- a/Shr2/HealthChecks/AzureStorageHealthCheck.cs
+++ b/Shr2/HealthChecks/AzureStorageHealthCheck.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;

--- a/Shr2/IConfig.cs
+++ b/Shr2/IConfig.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Shr2.Models;
+﻿using Shr2.Models;
 
 namespace Shr2
 {

--- a/Shr2/JConfig.cs
+++ b/Shr2/JConfig.cs
@@ -1,9 +1,4 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.IO;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Shr2.Models;
 using Shr2.Interfaces;
 

--- a/Shr2/JsonFileReader.cs
+++ b/Shr2/JsonFileReader.cs
@@ -1,9 +1,4 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.IO;
-using System.Text.Json;
+﻿using System.Text.Json;
 
 namespace Shr2
 {

--- a/Shr2/Models/Config.cs
+++ b/Shr2/Models/Config.cs
@@ -1,9 +1,4 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Shr2.Models
+﻿namespace Shr2.Models
 {
     public class Config
     {

--- a/Shr2/Models/GStyleRequest.cs
+++ b/Shr2/Models/GStyleRequest.cs
@@ -1,8 +1,4 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace Shr2.Models
 {

--- a/Shr2/Providers/AzTableStorage.cs
+++ b/Shr2/Providers/AzTableStorage.cs
@@ -1,8 +1,4 @@
-﻿﻿﻿using System;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Concurrent;
 using Azure;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;

--- a/Shr2/Services/ConverterService.cs
+++ b/Shr2/Services/ConverterService.cs
@@ -1,8 +1,4 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Text;
+﻿using System.Text;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Shr2.Interfaces;

--- a/Shr2/Services/Initializer.cs
+++ b/Shr2/Services/Initializer.cs
@@ -1,9 +1,4 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Shr2.Interfaces;


### PR DESCRIPTION
With ImplicitUsings enabled in .NET 9, System, System.Collections.Generic, System.Linq, and System.Threading.Tasks are automatically available. Remove these and other unused imports from all 15 affected files.
