### PR TITLE
Use named tuple elements for TryDecode and TryGetUrlAsync return types

### DIFF
--- a/Shr2.Interfaces/IConverter.cs
+++ b/Shr2.Interfaces/IConverter.cs
@@ -12,6 +12,6 @@ namespace Shr2.Interfaces
 
         //bool TryEncodeUrl(string url, out string idcode);
 
-        Task<(string url, bool permanent, bool preserveMethod)> TryDecode(string shortcode);
+        Task<(string Url, bool Permanent, bool PreserveMethod)> TryDecode(string shortcode);
     }
 }

--- a/Shr2.Interfaces/IStorageProvider.cs
+++ b/Shr2.Interfaces/IStorageProvider.cs
@@ -11,6 +11,6 @@ namespace Shr2.Interfaces
 
         Task<string> TryAddNewUrlAsync(string url, bool permanent = false, bool preserve = true, bool statsCount = false);
 
-        Task<(string url, bool permanent, bool preserveMethod)> TryGetUrlAsync(string idcode);
+        Task<(string Url, bool Permanent, bool PreserveMethod)> TryGetUrlAsync(string idcode);
     }
 }

--- a/Shr2/Controllers/RedirectController.cs
+++ b/Shr2/Controllers/RedirectController.cs
@@ -52,16 +52,16 @@ namespace Shr2.Controllers
 
                 var result = await _converter.TryDecode(id);
                 
-                if (string.IsNullOrEmpty(result.Item1))
+                if (string.IsNullOrEmpty(result.Url))
                 {
                     _logger?.LogWarning("No URL found for ID: {Id}", id);
                     return NotFound();
                 }
-                
-                _logger?.LogInformation("Redirecting {Id} to {Url} (Permanent: {Permanent}, PreserveMethod: {PreserveMethod})", 
-                    id, result.Item1, result.Item2, result.Item3);
-                
-                return new RedirectResult(result.Item1, result.Item2, result.Item3);
+
+                _logger?.LogInformation("Redirecting {Id} to {Url} (Permanent: {Permanent}, PreserveMethod: {PreserveMethod})",
+                    id, result.Url, result.Permanent, result.PreserveMethod);
+
+                return new RedirectResult(result.Url, result.Permanent, result.PreserveMethod);
             }
             catch (Exception ex)
             {

--- a/Shr2/Providers/AzTableStorage.cs
+++ b/Shr2/Providers/AzTableStorage.cs
@@ -108,7 +108,7 @@ namespace Shr2.Providers
             return (rownum.ToString(), tablekey);
         }
 
-        public async Task<(string url, bool permanent, bool preserveMethod)> TryGetUrlAsync(string idcode)
+        public async Task<(string Url, bool Permanent, bool PreserveMethod)> TryGetUrlAsync(string idcode)
         {
             if (idcode.Length >= 3 && Int64.TryParse(idcode, out long _))
             {

--- a/Shr2/Services/ConverterService.cs
+++ b/Shr2/Services/ConverterService.cs
@@ -68,25 +68,25 @@ namespace Shr2.Services
         /// </summary>
         /// <param name="shortcode">The short code to decode</param>
         /// <returns>Tuple containing the URL, permanent flag, and preserveMethod flag</returns>
-        public async Task<(string, bool, bool)> TryDecode(string shortcode)
+        public async Task<(string Url, bool Permanent, bool PreserveMethod)> TryDecode(string shortcode)
         {
             _logger?.LogInformation("Decoding shortcode: {ShortCode}", shortcode);
-            
+
             // Try to get from cache first
             var cacheKey = $"url_{shortcode}";
-            if (_cache.TryGetValue(cacheKey, out (string url, bool permanent, bool preserveMethod) result))
+            if (_cache.TryGetValue(cacheKey, out (string Url, bool Permanent, bool PreserveMethod) result))
             {
                 _logger?.LogInformation("Cache hit for shortcode: {ShortCode}", shortcode);
                 return result;
             }
-            
+
             try
             {
                 var storagekey = Decode(shortcode);
                 result = await _storageProvider.TryGetUrlAsync(storagekey);
-                
+
                 // Cache the result if URL was found
-                if (!string.IsNullOrEmpty(result.Item1))
+                if (!string.IsNullOrEmpty(result.Url))
                 {
                     var cacheOptions = new MemoryCacheEntryOptions()
                         .SetSlidingExpiration(TimeSpan.FromMinutes(10))


### PR DESCRIPTION
Replace unnamed tuple (string, bool, bool) with named elements (Url, Permanent, PreserveMethod) in IConverter, IStorageProvider, and their implementations. Update RedirectController to use named properties instead of Item1/Item2/Item3 for improved readability.