### PR TITLE
Replace magic string error signaling with EncodeResult type

### DIFF
--- a/Shr2.Interfaces/EncodeResult.cs
+++ b/Shr2.Interfaces/EncodeResult.cs
@@ -1,0 +1,26 @@
+namespace Shr2.Interfaces
+{
+    public class EncodeResult
+    {
+        public bool Success { get; }
+        public string? ShortCode { get; }
+        public EncodeError Error { get; }
+
+        private EncodeResult(bool success, string? shortCode, EncodeError error)
+        {
+            Success = success;
+            ShortCode = shortCode;
+            Error = error;
+        }
+
+        public static EncodeResult Ok(string shortCode) => new(true, shortCode, EncodeError.None);
+        public static EncodeResult Fail(EncodeError error) => new(false, null, error);
+    }
+
+    public enum EncodeError
+    {
+        None,
+        StorageError,
+        Conflict
+    }
+}

--- a/Shr2.Interfaces/IConverter.cs
+++ b/Shr2.Interfaces/IConverter.cs
@@ -8,9 +8,7 @@ namespace Shr2.Interfaces
     public interface IConverter
     {
 
-        Task<string> TryEncodeUrl(string url);
-
-        //bool TryEncodeUrl(string url, out string idcode);
+        Task<EncodeResult> TryEncodeUrl(string url);
 
         Task<(string url, bool permanent, bool preserveMethod)> TryDecode(string shortcode);
     }

--- a/Shr2.Interfaces/IStorageProvider.cs
+++ b/Shr2.Interfaces/IStorageProvider.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Shr2.Interfaces
+﻿namespace Shr2.Interfaces
 {
     public interface IStorageProvider
     {
         Task<bool> Init();
 
-        Task<string> TryAddNewUrlAsync(string url, bool permanent = false, bool preserve = true, bool statsCount = false);
+        Task<EncodeResult> TryAddNewUrlAsync(string url, bool permanent = false, bool preserve = true, bool statsCount = false);
 
         Task<(string url, bool permanent, bool preserveMethod)> TryGetUrlAsync(string idcode);
     }

--- a/Shr2/Controllers/V1Controller.cs
+++ b/Shr2/Controllers/V1Controller.cs
@@ -46,22 +46,17 @@ namespace Shr2.Controllers
                 _logger?.LogInformation("Test endpoint called");
                 var result = await _converter.TryEncodeUrl("http://www.google.com");
 
-                if (!string.IsNullOrEmpty(result) && result != "error")
+                if (result.Success)
                 {
-                    var shortUrl = _config.Domain + result;
+                    var shortUrl = _config.Domain + result.ShortCode;
                     _logger?.LogInformation("Test URL shortened: {ShortUrl}", shortUrl);
                     return Ok(shortUrl);
                 }
-                else if (result == "error")
-                {
-                    _logger?.LogError("Error processing test URL");
-                    return StatusCode(StatusCodes.Status500InternalServerError,
-                        new { error = "URL could not be processed, try again later." });
-                }
                 else
                 {
-                    _logger?.LogWarning("Bad request for test URL");
-                    return BadRequest(new { error = "Invalid request" });
+                    _logger?.LogError("Error processing test URL: {Error}", result.Error);
+                    return StatusCode(StatusCodes.Status500InternalServerError,
+                        new { error = "URL could not be processed, try again later." });
                 }
             }
             catch (Exception ex)
@@ -105,28 +100,23 @@ namespace Shr2.Controllers
 
                 var result = await _converter.TryEncodeUrl(request.LongUrl);
 
-                if (!string.IsNullOrEmpty(result) && result != "error")
+                if (result.Success)
                 {
                     var response = new
                     {
                         kind = "urlshortener#url",
-                        id = (_config.Domain + result),
+                        id = (_config.Domain + result.ShortCode),
                         longUrl = request.LongUrl
                     };
 
                     _logger?.LogInformation("URL shortened successfully: {ShortUrl}", response.id);
                     return Ok(response);
                 }
-                else if (result == "error")
-                {
-                    _logger?.LogError("Error processing URL: {LongUrl}", request.LongUrl);
-                    return StatusCode(StatusCodes.Status500InternalServerError,
-                        new { error = "URL could not be processed, try again later." });
-                }
                 else
                 {
-                    _logger?.LogWarning("Bad request for URL: {LongUrl}", request.LongUrl);
-                    return BadRequest(new { error = "Invalid URL format" });
+                    _logger?.LogError("Error processing URL: {LongUrl}, Error: {Error}", request.LongUrl, result.Error);
+                    return StatusCode(StatusCodes.Status500InternalServerError,
+                        new { error = "URL could not be processed, try again later." });
                 }
             }
             catch (Exception ex)

--- a/Shr2/Providers/AzTableStorage.cs
+++ b/Shr2/Providers/AzTableStorage.cs
@@ -47,7 +47,7 @@ namespace Shr2.Providers
             return true;
         }
 
-        public async Task<string> TryAddNewUrlAsync(string url, bool permanent = false, bool preserve = true, bool statsCount = false)
+        public async Task<EncodeResult> TryAddNewUrlAsync(string url, bool permanent = false, bool preserve = true, bool statsCount = false)
         {
             var id = GetNext();
             var entity = new ShorterData
@@ -64,7 +64,7 @@ namespace Shr2.Providers
             try
             {
                 await _tableClient.AddEntityAsync(entity);
-                
+
                 // Update index in background
                 _ = Task.Run(async () =>
                 {
@@ -73,8 +73,8 @@ namespace Shr2.Providers
                         await UpsertEntityAsync(new IndexEntity(entity.PartitionKey, "index", indexValue));
                     }
                 });
-                
-                return entity.PartitionKey + entity.RowKey;
+
+                return EncodeResult.Ok(entity.PartitionKey + entity.RowKey);
             }
             catch (RequestFailedException ex) when (ex.Status == 409) // Conflict
             {
@@ -85,13 +85,13 @@ namespace Shr2.Providers
                 }
                 else
                 {
-                    return string.Empty;
+                    return EncodeResult.Fail(EncodeError.Conflict);
                 }
             }
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Error adding URL: {Url}", url);
-                return "error";
+                return EncodeResult.Fail(EncodeError.StorageError);
             }
         }
 

--- a/Shr2/Services/ConverterService.cs
+++ b/Shr2/Services/ConverterService.cs
@@ -34,25 +34,25 @@ namespace Shr2.Services
         /// Returns a 'shortened' idcode of a given stored url ready to be encoded.
         /// </summary>
         /// <param name="url">The URL to encode</param>
-        /// <returns>The encoded short URL identifier</returns>
-        public async Task<string> TryEncodeUrl(string url)
+        /// <returns>An EncodeResult indicating success with the short code, or failure with an error</returns>
+        public async Task<EncodeResult> TryEncodeUrl(string url)
         {
             _logger?.LogInformation("Encoding URL: {Url}", url);
-            
+
             try
             {
-                var storagekey = await _storageProvider.TryAddNewUrlAsync(url);
-                
-                if (!string.IsNullOrWhiteSpace(storagekey) && storagekey != "error")
+                var result = await _storageProvider.TryAddNewUrlAsync(url);
+
+                if (result.Success)
                 {
-                    var encoded = Encode(storagekey);
+                    var encoded = Encode(result.ShortCode!);
                     _logger?.LogInformation("URL encoded successfully: {ShortCode}", encoded);
-                    return encoded;
+                    return EncodeResult.Ok(encoded);
                 }
                 else
                 {
-                    _logger?.LogWarning("Failed to encode URL: {Url}", url);
-                    return storagekey;
+                    _logger?.LogWarning("Failed to encode URL: {Url}, Error: {Error}", url, result.Error);
+                    return result;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Instead of returning "error" as a magic string from TryAddNewUrlAsync and propagating it through TryEncodeUrl, introduce an EncodeResult class with Success/Fail factory methods and an EncodeError enum (None, StorageError, Conflict). This makes error handling explicit and type-safe throughout the encoding pipeline.
