### PR TITLE
Register Initializer with AddHostedService instead of AddTransient

### DIFF
--- a/Shr2/Startup.cs
+++ b/Shr2/Startup.cs
@@ -35,7 +35,7 @@ namespace Shr2
             services.AddScoped<IConverter, ConverterService>();
             services.AddScoped<IStorageProvider, AzTableStorage>();
 
-            services.AddTransient<IHostedService, Initializer>();
+            services.AddHostedService<Initializer>();
 
             services.AddControllers();
             services.AddEndpointsApiExplorer();


### PR DESCRIPTION
AddHostedService<T>() is the correct way to register BackgroundService implementations. It registers as singleton and properly manages the service lifecycle (start/stop), unlike AddTransient<IHostedService> which creates a new instance per resolution.
